### PR TITLE
Remove list invocation

### DIFF
--- a/zsh/zsh/plugins.zsh
+++ b/zsh/zsh/plugins.zsh
@@ -12,4 +12,3 @@ zplug "plugins/dirhistory", from:oh-my-zsh
 
 
 zplug load
-zplug list


### PR DESCRIPTION
Make the zsh launch without executing the `zplug list`.